### PR TITLE
fix: add missing args to oauth deployment

### DIFF
--- a/env/oauth-proxy-jxui-frontend/values.tmpl.yaml
+++ b/env/oauth-proxy-jxui-frontend/values.tmpl.yaml
@@ -2,8 +2,8 @@ config:
   clientID: "{{ .Parameters.dashboardAuthID }}"
   clientSecret: "{{ .Parameters.dashboardAuthSecret }}"
 extraArgs:
+  cookie-secret: vault:arcalos-prod-mgmt/dashboard/cookie:secret
   email-domain: "*"
-  force-https: true
   oidc-issuer-url: "https://id.cloudbees.com/"
   pass-authorization-header: true
   pass-access-token: true


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>